### PR TITLE
Allow builds without running the app

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-if [ "$#" -eq 0 ]; then
-	echo "No command/process type specified"
-        exit 1
-fi
-
 if [ ! -d "/app" ]; then
 	if [ -n "$GIT_REPO" ]; then
           rm -rf /build/buildpacks
@@ -18,4 +13,8 @@ if [ ! -d "/app" ]; then
 	fi
 fi
 
-exec /exec "$@"
+if [ "$#" -eq 0 ]; then
+	echo "No command/process type specified"
+else
+        exec /exec "$@"
+fi


### PR DESCRIPTION
I would like to simply use Heroku build packs to build an app without running it if it's not needed. This change gives users the ability to use the centurylink/buildpack-runner image without "running" their app if they don't wish to.

If no extra args are passed into the run.sh script, it should inform the user and continue instead of exiting.
